### PR TITLE
Allow multiple deployments

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -3,7 +3,8 @@
 set -e
 
 TEMP_DIR="/tmp"
-PYTHON_FILE_SERVER_ROOT=${TEMP_DIR}/python-simple-http-webserver
+port=$(ctx node properties port)
+PYTHON_FILE_SERVER_ROOT=${TEMP_DIR}/cloudify-hello-world.$port
 if [ -d ${PYTHON_FILE_SERVER_ROOT} ]; then
 	echo "Removing file server root folder ${PYTHON_FILE_SERVER_ROOT}"
 	rm -rf ${PYTHON_FILE_SERVER_ROOT}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,12 +3,12 @@
 set -e
 
 TEMP_DIR="/tmp"
-PYTHON_FILE_SERVER_ROOT=${TEMP_DIR}/python-simple-http-webserver
+port=$(ctx node properties port)
+PYTHON_FILE_SERVER_ROOT=${TEMP_DIR}/cloudify-hello-world.$port
 PID_FILE="server.pid"
 
 ctx logger info "Starting HTTP server from ${PYTHON_FILE_SERVER_ROOT}"
 
-port=$(ctx node properties port)
 
 cd ${PYTHON_FILE_SERVER_ROOT}
 ctx logger info "Starting SimpleHTTPServer"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -3,7 +3,8 @@
 set -e
 
 TEMP_DIR="/tmp"
-PYTHON_FILE_SERVER_ROOT=${TEMP_DIR}/python-simple-http-webserver
+port=$(ctx node properties port)
+PYTHON_FILE_SERVER_ROOT=${TEMP_DIR}/cloudify-hello-world.$port
 PID_FILE="server.pid"
 
 PID=`cat ${PYTHON_FILE_SERVER_ROOT}/${PID_FILE}`


### PR DESCRIPTION
Given that the hello world example allows configuring the web server port, one thing that the user might try is to deploy the same blueprint multiple times on different ports. However, this doesn't work because the server directory is hardcoded meaning that all deployments share the same folder. Hence, when one of the deployments is uninstalled, the server files for all deployments are removed.

In this PR, the server directory is updated to depend on the port number, so that multiple deployments can be installed and uninstalled on different ports. 